### PR TITLE
[Fix] Template modal responsiveness

### DIFF
--- a/src/views/projects/templates/gallery.vue
+++ b/src/views/projects/templates/gallery.vue
@@ -241,6 +241,7 @@ export default {
   margin: 0 auto;
   padding: $unnnic-inline-md;
   display: grid;
+  overflow: auto;
 
   &.step-gallery {
     grid-template-columns: 13.9375rem 1fr;


### PR DESCRIPTION
Em telas com resoluções grandes foi relatado que o modal da galeria de templates estava quebrando, conforme imagem abaixo.

![image](https://github.com/weni-ai/weni-webapp/assets/54125469/394fcfc6-3dac-4879-ad9f-39f4d3fb3d48)

Para corrigir, incluímos a propriedade css "overflow: auto" para cortar o conteúdo do bloco e exibir uma barra de rolagem, ao invés do conteúdo transbordar o bloco.