### PR TITLE
Revert "hotfix: called directly from the integrations api temporarily"

### DIFF
--- a/src/api/projects.js
+++ b/src/api/projects.js
@@ -138,16 +138,10 @@ export default {
   },
 
   getWhatsAppDemoURL({ projectUuid }) {
-    return axios.get(
-      'https://integrations-engine.weni.ai/api/v1/apptypes/wpp-demo/apps/url/',
-      {
-        params: {
-          project: projectUuid,
-        },
-        headers: {
-          Authorization: 'Bearer ' + KCService.keycloak.token,
-        },
+    return request.$http().get('/v1/wpp-demo/url', {
+      params: {
+        project: projectUuid,
       },
-    );
+    });
   },
 };


### PR DESCRIPTION
When the local API request to get WhatsApp Demo URL is working, this revert branch can be merged.