### PR TITLE
Hide doris when setting up chats page is actived

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -85,6 +85,7 @@ const routes = [
         meta: {
           requiresAuth: true,
           title: 'pages.settings',
+          hideBottomRightOptions: true,
         },
       },
     ],


### PR DESCRIPTION
To avoid any usability issues, Doris is not visible when accessing the page for setting up chats.