### PR TITLE
Feature/project description manager

### DIFF
--- a/src/components/common/RightBar/ProjectSettings.vue
+++ b/src/components/common/RightBar/ProjectSettings.vue
@@ -63,6 +63,7 @@ import { mapActions } from 'vuex';
 import { openAlertModal } from '../../../utils/openServerErrorAlertModal';
 import ProjectDescriptionTextarea from '../../../views/projects/form/DescriptionTextarea.vue';
 import timezones from './../../../views/projects/timezone';
+import ProjectDescriptionChanges from '../../../utils/ProjectDescriptionChanges';
 
 export default {
   mixins: [timezones],
@@ -128,6 +129,11 @@ export default {
           name: this.name,
           description: this.description,
           timezone: this.timezone,
+        });
+
+        ProjectDescriptionChanges.register({
+          projectUuid: this.projectUuid,
+          description: response.data?.description || '',
         });
 
         openAlertModal({

--- a/src/components/projects/ProjectList.vue
+++ b/src/components/projects/ProjectList.vue
@@ -65,6 +65,8 @@ import { mapActions, mapState } from 'vuex';
 import { getTimeAgo } from '../../utils/plugins/timeAgo';
 import ProjectListItem from './ProjectListItem';
 import localStorageSaver from './localStorageSaver.js';
+import ProjectDescriptionChanges from '../../utils/ProjectDescriptionChanges';
+import { get } from 'lodash';
 
 export default {
   name: 'ProjectList',
@@ -201,10 +203,21 @@ export default {
         })
         .then(() => {
           setTimeout(() => {
+            if (this.orgProjects.status === 'complete') {
+              return;
+            }
+
             if (
-              this.isInfiniteLoadingElementShowed &&
-              this.orgProjects.status !== 'complete'
+              get(this.$route, 'query.edit_project_uuid') &&
+              !ProjectDescriptionChanges.project({
+                projectUuid: get(this.$route, 'query.edit_project_uuid'),
+              })
             ) {
+              this.loadNextProjects();
+              return;
+            }
+
+            if (this.isInfiniteLoadingElementShowed) {
               this.loadNextProjects();
             }
           }, 0);

--- a/src/components/projects/ProjectListItem.vue
+++ b/src/components/projects/ProjectListItem.vue
@@ -44,30 +44,7 @@
           {{ $t('orgs.manage_members') }}
         </unnnic-dropdown-item>
 
-        <unnnic-dropdown-item
-          v-if="canManageMembers"
-          @click="
-            $store.dispatch('openRightBar', {
-              props: {
-                type: 'ProjectSettings',
-                projectUuid: project.uuid,
-                projectName: project.name,
-                projectDescription: project.description,
-                projectTimezone: project.timezone,
-                projectAuthorizations: authorizations.users,
-                projectPendingAuthorizations: pendingAuthorizations.users,
-                projectHasChat: hasChat,
-              },
-
-              events: {
-                'added-authorization': addedAuthorization,
-                'deleted-authorization': deleteUser,
-                'changed-role-authorization': changedRoleAuthorization,
-                'updated-project': updatedProject,
-              },
-            })
-          "
-        >
+        <unnnic-dropdown-item v-if="canManageMembers" @click="openEditProject">
           <unnnic-icon-svg size="sm" icon="pencil-write-1" />
           {{ $t('projects.edit_name') }}
         </unnnic-dropdown-item>
@@ -104,6 +81,7 @@ import {
   PROJECT_ROLE_MODERATOR,
   PROJECT_ROLE_CONTRIBUTOR,
 } from '../users/permissionsObjects';
+import { get } from 'lodash';
 
 export default {
   name: 'ProjectListItem',
@@ -143,7 +121,20 @@ export default {
     return {};
   },
 
-  created() {},
+  watch: {
+    'project.uuid': {
+      immediate: true,
+      handler() {
+        if (
+          get(this.$route, 'query.edit_project_uuid') === this.project.uuid &&
+          !window.alreadyOpenedEditProject
+        ) {
+          window.alreadyOpenedEditProject = true;
+          this.openEditProject();
+        }
+      },
+    },
+  },
 
   computed: {
     canManageMembers() {
@@ -183,6 +174,32 @@ export default {
   },
 
   methods: {
+    openEditProject() {
+      if (!this.canManageMembers) {
+        return;
+      }
+
+      this.$store.dispatch('openRightBar', {
+        props: {
+          type: 'ProjectSettings',
+          projectUuid: this.project.uuid,
+          projectName: this.project.name,
+          projectDescription: this.project.description,
+          projectTimezone: this.project.timezone,
+          projectAuthorizations: this.authorizations.users,
+          projectPendingAuthorizations: this.pendingAuthorizations.users,
+          projectHasChat: this.hasChat,
+        },
+
+        events: {
+          'added-authorization': this.addedAuthorization,
+          'deleted-authorization': this.deleteUser,
+          'changed-role-authorization': this.changedRoleAuthorization,
+          'updated-project': this.updatedProject,
+        },
+      });
+    },
+
     addedAuthorization($event) {
       this.$emit('added-authorization', $event);
     },

--- a/src/utils/ProjectDescriptionChanges.js
+++ b/src/utils/ProjectDescriptionChanges.js
@@ -1,0 +1,78 @@
+import store from '../store';
+
+export default {
+  register({ projectUuid, description }) {
+    let projectDescriptions = JSON.parse(
+      localStorage.getItem('project-descriptions') || '[]',
+    );
+
+    const projectDescription = projectDescriptions.find(
+      ({ uuid }) => uuid === projectUuid,
+    );
+
+    if (projectDescription) {
+      projectDescription.description = description;
+      projectDescription.updatedAt = new Date();
+    } else {
+      projectDescriptions.push({
+        uuid: projectUuid,
+        description,
+        updatedAt: new Date(),
+      });
+    }
+
+    localStorage.setItem(
+      'project-descriptions',
+      JSON.stringify(projectDescriptions),
+    );
+  },
+
+  project({ projectUuid }) {
+    return store.state.Project.projects
+      .map(({ data }) => data)
+      .flat()
+      .find(({ uuid }) => uuid === projectUuid);
+  },
+
+  isChanged({ projectUuid }) {
+    let changed = false;
+
+    let projectDescriptions = JSON.parse(
+      localStorage.getItem('project-descriptions') || '[]',
+    );
+
+    const projectDescription = projectDescriptions.find(
+      ({ uuid }) => uuid === projectUuid,
+    );
+
+    const project = this.project({ projectUuid });
+
+    if (
+      projectDescription &&
+      project?.description &&
+      projectDescription.description !== project?.description
+    ) {
+      project.description = projectDescription.description;
+      changed = true;
+    }
+
+    const remove = projectDescriptions.filter(
+      (projectDescription) =>
+        (new Date() - new Date(projectDescription.updatedAt)) / 1000 > 6,
+    );
+
+    if (remove.length) {
+      const final = projectDescriptions.filter(
+        ({ uuid }) => !remove.some((toRemove) => toRemove.uuid === uuid),
+      );
+
+      if (final.length) {
+        localStorage.setItem('project-descriptions', JSON.stringify(final));
+      } else {
+        localStorage.removeItem('project-descriptions');
+      }
+    }
+
+    return changed;
+  },
+};


### PR DESCRIPTION
* Create a project description changes manager to access changes in the project description from another opened tabs;
* Provide a redirect to a new tab to open edit project from a project uuid automatically.

The Flows module can listen to `setConnectProjectDescription` event name by:

```js
window.addEventListener('message', (event) => {
  if (event.data?.event === 'setConnectProjectDescription') {
    console.log('received', event.data);
    /* {
      event:  'setConnectProjectDescription',
      connectProjectUuid: 'Uuid String',
      connectProjectDescription: 'String',
    } */
  }
});
```

And can send `getConnectProjectDescription` and `openConnectEditProject` events:

```js
// force receive setConnectProjectDescription event with the current description
window.parent.postMessage(
  { event: 'getConnectProjectDescription', },
  '*'
);
```

```js
// open edit project sidebar in a new tab
window.parent.postMessage(
  { event: 'openConnectEditProject', },
  '*'
);
```
