### PR TITLE
[NEXUS-2094] - Added intelligences iframe medias permissions

### DIFF
--- a/src/components/SystemIntelligences.vue
+++ b/src/components/SystemIntelligences.vue
@@ -13,7 +13,7 @@
       v-show="!loading"
       ref="iframe"
       class="container container--full-height"
-      allow="clipboard-read; clipboard-write;"
+      allow="clipboard-read; clipboard-write; microphone; geolocation;"
       frameborder="0"
       @load="load"
     ></iframe>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
To contemplate the feature of viewing media in the agent builder preview, it is necessary to explicitly specify audio recording permissions and request geolocation in your iframe.

### Summary of Changes
Added `microphone` and `geolocation` permission at intelligences iframe.
