### PR TITLE
[CFE-399] - Fix page not found at Intelligences modules 

### DIFF
--- a/src/components/SystemIntelligences.vue
+++ b/src/components/SystemIntelligences.vue
@@ -80,7 +80,7 @@ export default {
           next = this.paths[this.$route.name].join('/');
         }
       } else {
-        next = internal?.join('/');
+        next = internal?.join('/') || '';
       }
 
       return {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When users changed organizations and tried to open an intelligence module, they received the error "Page not found", as shown below.

### Summary of Changes
A validation was added to not return the module redirect as `undefined`, but as an `empty string`, thus resolving the bug.

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/user-attachments/assets/8b2662bb-4321-466f-8d4a-5949f4f71a61)
