### PR TITLE
[NEXUS-2722] - Added Agents Builder as module that accepts redirection

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -544,6 +544,7 @@ export default {
         const modulesToRouteName = {
           'chats-settings': 'settingsChats',
           intelligences: 'bothub',
+          'agents-builder': 'brain',
           flows: 'push',
         };
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The Bothub module needed to be redirected to the Agents Builder module for a new feature

### Summary of Changes
Added `agents-builder` key-value at modulesToRouteName variable
