### PR TITLE
[CFE-625] - Federated Modules error handling

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -33,9 +33,9 @@ module.exports = defineConfig({
   output: {
     path: path.resolve(__dirname, './dist'),
     publicPath: process.env.PUBLIC_PATH_URL,
-    filename: '/assets/js/[name]-[contenthash].js',
-    chunkFilename: '/assets/js/[name]-[contenthash].js',
-    assetModuleFilename: '/assets/[name]-[hash][ext]',
+    filename: 'assets/js/[name]-[contenthash].js',
+    chunkFilename: 'assets/js/[name]-[contenthash].js',
+    assetModuleFilename: 'assets/[name]-[hash][ext]',
   },
   entry: {
     main: './src/main.js',
@@ -67,7 +67,7 @@ module.exports = defineConfig({
         test: /\.(png|jpe?g|gif|svg|webp|avif)$/i,
         type: 'asset/resource',
         generator: {
-          filename: '/assets/images/[name]-[hash][ext]',
+          filename: 'assets/images/[name]-[hash][ext]',
         },
       },
     ],

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -116,7 +116,7 @@ module.exports = defineConfig({
           eager: true,
         },
       },
-      filename: '/remoteEntry.js',
+      filename: 'remoteEntry.js',
     }),
   ],
   optimization: {

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -87,7 +87,7 @@ module.exports = defineConfig({
       __VUE_PROD_DEVTOOLS__: false,
       'process.env': JSON.stringify(formatEnv(process.env)),
       'import.meta.env': JSON.stringify({
-        BASE_URL: process.env.BASE_URL || '/',
+        BASE_URL: '/',
       }),
     }),
     new VueLoaderPlugin(),

--- a/src/components/RemoteComponents.vue
+++ b/src/components/RemoteComponents.vue
@@ -1,10 +1,10 @@
 <script setup>
-import { defineAsyncComponent } from 'vue';
+import { safeAsyncComponent } from '@/utils/moduleFederation';
 
-const RemoteDiscoveryCommerce = defineAsyncComponent(
+const RemoteDiscoveryCommerce = safeAsyncComponent(
   () => import('commerce/solution-card'),
 );
-const RemoteDashboardInsights = defineAsyncComponent(
+const RemoteDashboardInsights = safeAsyncComponent(
   () => import('insights/dashboard-commerce'),
 );
 
@@ -17,11 +17,9 @@ const props = defineProps({
 </script>
 
 <template>
-  <RemoteDashboardInsights
-    v-if="!!RemoteDashboardInsights && props.auth.token && props.auth.uuid"
-  />
+  <RemoteDashboardInsights v-if="props.auth.token && props.auth.uuid" />
   <RemoteDiscoveryCommerce
-    v-if="!!RemoteDiscoveryCommerce && props.auth.token && props.auth.uuid"
+    v-if="props.auth.token && props.auth.uuid"
     type="remote"
   />
 </template>

--- a/src/utils/moduleFederation.js
+++ b/src/utils/moduleFederation.js
@@ -1,0 +1,61 @@
+import { defineAsyncComponent } from 'vue';
+import * as Sentry from '@sentry/browser';
+
+/**
+ * Simple safe import utility for module federation
+ * Use with defineAsyncComponent for Vue components
+ */
+
+/**
+ * Creates a safe async component with automatic defineAsyncComponent wrapper
+ * @param {Function} importFn - The import function (e.g., () => import('remote/component'))
+ * @param {any} fallback - Fallback component if import fails
+ * @returns {Component} - Vue async component ready to use
+ */
+export function safeAsyncComponent(importFn) {
+  return defineAsyncComponent(async () => {
+    try {
+      return await importFn();
+    } catch (error) {
+      console.error(
+        '[Module Federation] Failed to load remote component:',
+        error.message,
+      );
+
+      Sentry.captureException(error, {
+        tags: {
+          module_federation: true,
+          error_type: 'component_load_failed',
+        },
+        extra: {
+          errorMessage: error.message,
+          stack: error.stack,
+        },
+      });
+    }
+  });
+}
+
+/**
+ * Safe import for files
+ * @param {Function} importFn - The import function (e.g., () => import('remote/locales/en'))
+ * @param {string} importPath - The import path for logging purposes
+ * @returns {Promise<Object>} - The imported object or empty object
+ */
+export async function safeImport(importFn, importPath) {
+  try {
+    const module = await importFn();
+    return module.default || module;
+  } catch (error) {
+    console.error(
+      `[Module Federation] ${importPath} unavailable:`,
+      error.message,
+    );
+
+    Sentry.captureException(error, {
+      tags: { module_federation: true, import_path: importPath },
+    });
+
+    return {};
+  }
+}

--- a/src/utils/moduleFederation.js
+++ b/src/utils/moduleFederation.js
@@ -2,11 +2,6 @@ import { defineAsyncComponent } from 'vue';
 import * as Sentry from '@sentry/browser';
 
 /**
- * Simple safe import utility for module federation
- * Use with defineAsyncComponent for Vue components
- */
-
-/**
  * Creates a safe async component with automatic defineAsyncComponent wrapper
  * @param {Function} importFn - The import function (e.g., () => import('remote/component'))
  * @param {any} fallback - Fallback component if import fails

--- a/src/utils/plugins/i18n.js
+++ b/src/utils/plugins/i18n.js
@@ -1,17 +1,41 @@
 import { createI18n } from 'vue-i18n';
+import { safeImport } from '@/utils/moduleFederation';
 
 import en from '@/locales/en.json';
 import es from '@/locales/es.json';
 import pt_br from '@/locales/pt_br.json';
-const insightsEn = await import('insights/locales/en');
-const insightsEs = await import('insights/locales/es');
-const insightsPtBr = await import('insights/locales/pt_br');
-const commerceEn = await import('commerce/locales/en_us');
-const commerceEs = await import('commerce/locales/es_es');
-const commercePtBr = await import('commerce/locales/pt_br');
+
+const insightsEn = await safeImport(
+  () => import('insights/locales/en'),
+  'insights/locales/en',
+);
+const insightsEs = await safeImport(
+  () => import('insights/locales/es'),
+  'insights/locales/es',
+);
+const insightsPtBr = await safeImport(
+  () => import('insights/locales/pt_br'),
+  'insights/locales/pt_br',
+);
+const commerceEn = await safeImport(
+  () => import('commerce/locales/en_us'),
+  'commerce/locales/en_us',
+);
+const commerceEs = await safeImport(
+  () => import('commerce/locales/es_es'),
+  'commerce/locales/es_es',
+);
+const commercePtBr = await safeImport(
+  () => import('commerce/locales/pt_br'),
+  'commerce/locales/pt_br',
+);
 
 function mergeLocales(base, ...modules) {
-  return Object.assign({}, base, ...modules);
+  const validModules = modules.filter(
+    (module) =>
+      module && typeof module === 'object' && Object.keys(module).length > 0,
+  );
+  return Object.assign({}, base, ...validModules);
 }
 
 const portuguese = mergeLocales(pt_br, insightsPtBr, commercePtBr);

--- a/tests/unit/utils/moduleFederation.spec.js
+++ b/tests/unit/utils/moduleFederation.spec.js
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as Sentry from '@sentry/browser';
+import { safeAsyncComponent, safeImport } from '@/utils/moduleFederation';
+
+vi.mock('@sentry/browser', () => ({
+  captureException: vi.fn(),
+}));
+
+describe('moduleFederation.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('safeAsyncComponent', () => {
+    it('should return a Vue async component definition', () => {
+      const mockComponent = {};
+      const mockImportFn = vi.fn().mockResolvedValue(mockComponent);
+
+      const result = safeAsyncComponent(mockImportFn);
+
+      expect(result).toBeDefined();
+      expect(typeof result).toBe('object');
+      expect(result.name).toBe('AsyncComponentWrapper');
+
+      expect(mockImportFn).not.toHaveBeenCalled();
+      expect(console.error).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('should successfully load component when import succeeds', async () => {
+      const mockComponent = {
+        name: 'TestComponent',
+        template: '<div>Test</div>',
+      };
+      const mockImportFn = vi.fn().mockResolvedValue(mockComponent);
+
+      const asyncComponent = safeAsyncComponent(mockImportFn);
+
+      const result = await asyncComponent.__asyncLoader();
+
+      expect(mockImportFn).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mockComponent);
+      expect(console.error).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('should handle import failure and log errors', async () => {
+      const mockError = new Error('Module not found');
+      const mockImportFn = vi.fn().mockRejectedValue(mockError);
+
+      const asyncComponent = safeAsyncComponent(mockImportFn);
+
+      let result;
+      try {
+        result = await asyncComponent.__asyncLoader();
+      } catch (error) {
+        result = undefined;
+      }
+
+      expect(mockImportFn).toHaveBeenCalledTimes(1);
+      expect(result).toBeUndefined();
+      expect(console.error).toHaveBeenCalledWith(
+        '[Module Federation] Failed to load remote component:',
+        'Module not found',
+      );
+    });
+
+    it('should handle errors without error message', async () => {
+      const mockError = new Error();
+      const mockImportFn = vi.fn().mockRejectedValue(mockError);
+
+      const asyncComponent = safeAsyncComponent(mockImportFn);
+
+      let result;
+      try {
+        result = await asyncComponent.__asyncLoader();
+      } catch (error) {
+        result = undefined;
+      }
+
+      expect(result).toBeUndefined();
+      expect(console.error).toHaveBeenCalledWith(
+        '[Module Federation] Failed to load remote component:',
+        '',
+      );
+    });
+  });
+
+  describe('safeImport', () => {
+    describe('successful import', () => {
+      it('should return the module when import succeeds', async () => {
+        const mockModule = { someFunction: vi.fn() };
+        const mockImportFn = vi.fn().mockResolvedValue(mockModule);
+
+        const result = await safeImport(mockImportFn, 'test/module');
+
+        expect(mockImportFn).toHaveBeenCalledTimes(1);
+        expect(result).toBe(mockModule);
+        expect(console.error).not.toHaveBeenCalled();
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+      });
+
+      it('should return module.default when available', async () => {
+        const defaultExport = { someFunction: vi.fn() };
+        const mockModule = { default: defaultExport, otherExport: 'other' };
+        const mockImportFn = vi.fn().mockResolvedValue(mockModule);
+
+        const result = await safeImport(mockImportFn, 'test/module');
+
+        expect(result).toBe(defaultExport);
+      });
+
+      it('should return the whole module when no default export', async () => {
+        const mockModule = { namedExport: vi.fn(), anotherExport: 'value' };
+        const mockImportFn = vi.fn().mockResolvedValue(mockModule);
+
+        const result = await safeImport(mockImportFn, 'test/module');
+
+        expect(result).toBe(mockModule);
+      });
+
+      it('should handle module with falsy default export', async () => {
+        const mockModule = { default: null, namedExport: 'value' };
+        const mockImportFn = vi.fn().mockResolvedValue(mockModule);
+
+        const result = await safeImport(mockImportFn, 'test/module');
+
+        expect(result).toBe(mockModule);
+      });
+    });
+
+    describe('failed import', () => {
+      it('should handle import failure and return empty object', async () => {
+        const mockError = new Error('Module not found');
+        const mockImportFn = vi.fn().mockRejectedValue(mockError);
+
+        const result = await safeImport(mockImportFn, 'test/module');
+
+        expect(result).toEqual({});
+        expect(console.error).toHaveBeenCalledWith(
+          '[Module Federation] test/module unavailable:',
+          'Module not found',
+        );
+      });
+
+      it('should handle errors without error message', async () => {
+        const mockError = new Error();
+        const mockImportFn = vi.fn().mockRejectedValue(mockError);
+
+        const result = await safeImport(mockImportFn, 'test/module');
+
+        expect(result).toEqual({});
+        expect(console.error).toHaveBeenCalledWith(
+          '[Module Federation] test/module unavailable:',
+          '',
+        );
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle undefined import function', async () => {
+        const result = await safeImport(undefined, 'test/module');
+
+        expect(result).toEqual({});
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('should handle null import function', async () => {
+        const result = await safeImport(null, 'test/module');
+
+        expect(result).toEqual({});
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('should handle undefined import path', async () => {
+        const mockError = new Error('Test error');
+        const mockImportFn = vi.fn().mockRejectedValue(mockError);
+
+        const result = await safeImport(mockImportFn, undefined);
+
+        expect(result).toEqual({});
+        expect(console.error).toHaveBeenCalledWith(
+          '[Module Federation] undefined unavailable:',
+          'Test error',
+        );
+      });
+
+      it('should handle import function that returns null', async () => {
+        const mockImportFn = vi.fn().mockResolvedValue(null);
+
+        const result = await safeImport(mockImportFn, 'test/module');
+
+        expect(result).toEqual({});
+      });
+
+      it('should handle network timeout errors', async () => {
+        const timeoutError = new Error('Request timeout');
+        timeoutError.name = 'TimeoutError';
+        const mockImportFn = vi.fn().mockRejectedValue(timeoutError);
+
+        const result = await safeImport(mockImportFn, 'remote/component');
+
+        expect(result).toEqual({});
+        expect(console.error).toHaveBeenCalledWith(
+          '[Module Federation] remote/component unavailable:',
+          'Request timeout',
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [x] Other

### Motivation and Context
The host (connect) was tightly coupled to the remotes, and would fail completely if any of the remotes were unavailable. This would cause application loading crashes.

### Summary of Changes
- Two utilities have been added for dynamic import:
  - One for generic files
  - Another for components
  
  Both use `try...catch` to catch failures when trying to import remotes. In case of an error, the failure is recorded in the console and in Sentry, preventing the host from being interrupted by remote unavailability.

- Added unit tests for the created utilities.
- Fixed the file paths and remoteEntry in the Rspack configuration, avoiding duplication of `/`, as was occurring.

### Demonstration
![image](https://github.com/user-attachments/assets/f48b7b19-f7e2-4d92-b0bd-3d14c42b1013)
