### PR TITLE
fix: display project settings for all project types

### DIFF
--- a/src/views/settings.vue
+++ b/src/views/settings.vue
@@ -104,7 +104,7 @@ export default {
     pages() {
       const options = [];
 
-      if (!this.hideModulesButChats && !this.isCommerceProject) {
+      if (!this.hideModulesButChats) {
         options.push({
           key: 'projectConfig',
           label: this.$t('settings.project.title'),


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
For now, commerce projects still need access to the deprecated project configuration page
