### PR TITLE
fix: update route name from 'brain' to 'agent-builder' in org creation redirect

### DIFF
--- a/src/views/register/ModalCreateProjectSuccess.vue
+++ b/src/views/register/ModalCreateProjectSuccess.vue
@@ -58,7 +58,7 @@ function redirectToTheProject() {
 
   if (props.createdBrain) {
     router.push({
-      name: 'brain',
+      name: 'agent-builder',
       params: {
         projectUuid: props.projectUuid,
         internal: ['init'],


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
After created, the redirect was not working since the `brain` route was renamed

### Summary of Changes
Changed to use the correct route
