### PR TITLE
feat(org-card): add text truncation for organization description

### DIFF
--- a/src/components/orgs/OrgCard.vue
+++ b/src/components/orgs/OrgCard.vue
@@ -172,6 +172,13 @@ export default {
     line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
 
     margin: 0;
+
+    display: -webkit-box;
+    line-clamp: 2;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .tag {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Longer descriptions were causing  an improper card size

### Summary of Changes
Added truncation and a 2 line limit
