### PR TITLE
fix: force bulkSend remount on sidebar option navigation

### DIFF
--- a/src/components/Sidebar/SidebarOption.vue
+++ b/src/components/Sidebar/SidebarOption.vue
@@ -193,6 +193,8 @@ function navigate(defaultNavigate) {
   if (isCurrentRoute) {
     if (url?.includes('insights')) {
       window.dispatchEvent(new CustomEvent('forceRemountInsights'));
+    } else if (url?.includes('bulkSend')) {
+      window.dispatchEvent(new CustomEvent('forceRemountBulkSend'));
     }
 
     if (url?.includes('agent-builder')) {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Ensure bulkSend is remounted on navigation

### Summary of Changes
Added force remount event
