### PR TITLE
fix: add null checks for modalCreatingProject before calling onCloseClick

### DIFF
--- a/src/views/register/index.vue
+++ b/src/views/register/index.vue
@@ -580,9 +580,7 @@ export default {
       if (this.haveBeenInvitedView) {
         await this.updateUserInformation();
 
-        if (this.$refs.modalCreatingProject) {
-          this.$refs.modalCreatingProject.onCloseClick();
-        }
+        this.$refs.modalCreatingProject?.onCloseClick();
 
         this.openWelcomeModal();
 
@@ -671,9 +669,7 @@ export default {
 
       this.createdProject = project;
 
-      if (this.$refs.modalCreatingProject) {
-        this.$refs.modalCreatingProject.onCloseClick();
-      }
+      this.$refs.modalCreatingProject?.onCloseClick();
       this.isModalCreateProjectSuccessOpen = true;
     },
 

--- a/src/views/register/index.vue
+++ b/src/views/register/index.vue
@@ -580,7 +580,9 @@ export default {
       if (this.haveBeenInvitedView) {
         await this.updateUserInformation();
 
-        this.$refs.modalCreatingProject.onCloseClick();
+        if (this.$refs.modalCreatingProject) {
+          this.$refs.modalCreatingProject.onCloseClick();
+        }
 
         this.openWelcomeModal();
 
@@ -669,7 +671,9 @@ export default {
 
       this.createdProject = project;
 
-      this.$refs.modalCreatingProject.onCloseClick();
+      if (this.$refs.modalCreatingProject) {
+        this.$refs.modalCreatingProject.onCloseClick();
+      }
       this.isModalCreateProjectSuccessOpen = true;
     },
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Prevent calling onCloseCLick on undefined ref
