### PR TITLE
[NEXUS-3845] - Allow Agent Builder 2.0 to run via iframe instead of module federation

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -108,7 +108,11 @@
           <SystemInsights :modelValue="$route.name?.includes('insights')" />
           <SystemBulkSend :modelValue="$route.name?.includes('bulkSend')" />
 
-          <SystemIntelligences />
+          <SystemAgentBuilder
+            v-if="featureFlagsStore.flags.agentsTeam"
+            :modelValue="$route.name?.includes('agentBuilder')"
+          />
+          <SystemIntelligences v-else />
         </div>
       </div>
 

--- a/src/app.vue
+++ b/src/app.vue
@@ -108,11 +108,7 @@
           <SystemInsights :modelValue="$route.name?.includes('insights')" />
           <SystemBulkSend :modelValue="$route.name?.includes('bulkSend')" />
 
-          <SystemAgentBuilder
-            v-if="featureFlagsStore.flags.agentsTeam"
-            :modelValue="$route.name?.includes('agentBuilder')"
-          />
-          <SystemIntelligences v-else />
+          <SystemIntelligences />
         </div>
       </div>
 

--- a/src/components/ExternalSystem.vue
+++ b/src/components/ExternalSystem.vue
@@ -329,6 +329,10 @@ export default {
         this.$keycloak.logout();
       } else if (eventName === 'getToken') {
         sendAllIframes('updateToken', { token: this.$keycloak.token });
+      } else if (eventName === 'getProjectUuid') {
+        sendAllIframes('updateProjectUuid', {
+          projectUuid: this.$route.params.projectUuid,
+        });
       }
     });
   },
@@ -460,6 +464,8 @@ export default {
           this.chatsRedirect();
         } else if (this.routes.includes('insights')) {
           this.insightsRedirect();
+        } else if (this.routes.includes('agentBuilder')) {
+          this.agentBuilderRedirect();
         } else if (this.routes.includes('settingsProject')) {
           this.projectRedirect();
         } else if (this.routes.includes('settingsChats')) {
@@ -634,6 +640,37 @@ export default {
       try {
         const url = this.urls.insights;
 
+        let next = this.nextParam;
+
+        if (defaultNext) {
+          next = next ? next : defaultNext;
+        }
+
+        next = next.replace(/(\?next=)\/?(.+)/, '$1/$2');
+
+        next = new URLSearchParams(next);
+
+        if (this.currentProject?.uuid) {
+          next.append('projectUuid', this.currentProject.uuid);
+        }
+
+        const { query: routeQuery } = this.$route;
+
+        Object.entries(routeQuery).forEach(([key, value]) => {
+          next.append(key, value);
+        });
+
+        const src = url + `?${next.toString()}`;
+
+        this.setSrc(src);
+      } catch (e) {
+        return e;
+      }
+    },
+
+    async agentBuilderRedirect(defaultNext) {
+      try {
+        const url = this.urls.agent_builder;
         let next = this.nextParam;
 
         if (defaultNext) {

--- a/src/components/SystemIntelligences.vue
+++ b/src/components/SystemIntelligences.vue
@@ -128,6 +128,12 @@ export default {
         this.reload();
       }
     }, 5000),
+
+    'featureFlagsStore.flags.agentsTeam': {
+      handler() {
+        this.reload();
+      },
+    },
   },
 
   mounted() {
@@ -209,7 +215,9 @@ export default {
         const { inteligence_organization } = this.currentOrg;
         const { uuid } = this.currentProject;
 
-        const apiUrl = this.urls.intelligence;
+        const apiUrl = this.featureFlagsStore.flags.agentsTeam
+          ? this.urls.agent_builder
+          : this.urls.intelligence;
         if (!apiUrl) return null;
 
         const { owner, slug } = this.$route.params;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow Agent Builder 2.0 to run via iframe instead of module federation

### Summary of Changes
<!--- Describe your changes in detail -->
- Mapped agent_builder to ExternalSystem;
- Changed SystemAgentBuilder to call ExternalSystem instead of building the application via Module Federation;
- Added validation in SystemIntelligences to switch to Agent Builder if the agentsTeam Feature Flag is true.